### PR TITLE
advertising: tweak to long announcement

### DIFF
--- a/content/communication/announcement-long.md
+++ b/content/communication/announcement-long.md
@@ -13,7 +13,7 @@ Do you struggle to reproduce results of your own or others computations?
 Join the [CodeRefinery workshop](http://coderefinery.github.io/2025-09-09-workshop/) in September and October!
 It takes place **online** on 9 half days (you can pick and choose)
 
--   **What**: **Intro to git and collaborative git, on github**
+-   **What**: **Intro to git and collaborative git, on GitHub**
     **When**: 3 days in the second week of September (9+10+11 September 11:00-13:00 + 14:00-15:30 (CEST))
 -   **What**: **Reproducible research**, **tools for documentation and testing**, **modular code development**
     **When**: spread over 6 following weeks Wednesdays starting on 17th of September until the 22nd of October.
@@ -22,7 +22,7 @@ The intended audience for this workshop are researchers of all domains, levels a
 
 The workshop is held **online** (streamed on Twitch) with hands-on sessions.
 Interaction with the participants and live help is guaranteed by a variety of means.
-Some locations may offer in-person events (check the [event page](https://coderefinery.github.io/2025-09-09-workshop/)), and **feel encouraged to join as a team** with your colleagues and form your own classroom (please contact us if this option sparks your interest).
+Some locations may offer in-person events (check the [event page](https://coderefinery.github.io/2025-09-09-workshop/)), and **feel encouraged to join as a team** with your colleagues or [bring your own classroom](https://coderefinery.org/blog/bring-your-own-classroom/) (please contact us if this option sparks your interest).
 
 The event is free of charge.
 More info and registration on the [CodeRefinery Workshop site](https://coderefinery.github.io/2025-09-09-workshop/).

--- a/content/communication/announcement-long.md
+++ b/content/communication/announcement-long.md
@@ -4,23 +4,27 @@ title = "Workshop announcement example (longer version)"
 subject = "CodeRefinery workshop announcement"
 +++
 
-CodeRefinery workshop on tools and techniques for reproducible research
+# CodeRefinery workshop on tools and techniques for reproducible research
 
 Are you writing code for your research?
+Do you want to make your research results more reproducible?
 Do you struggle to reproduce results of your own or others computations?
 
-Join the online CodeRefinery workshop on nine half days: 
-- Intro to git and collaborative git: 9+10+11/September 11:00-13:00 + 14:00-15:30 (CEST)
-- Reproducible research and other topics spread over 6 following weeks Wednesdays with exercises: 17.9+24.9+1.10+8.10+15.10 + 22.10.
+Join the [CodeRefinery workshop](http://coderefinery.github.io/2025-09-09-workshop/) in September and October!
+It takes place **online** on 9 half days (you can pick and choose)
 
-The CodeRefinery workshop aims to support researchers of all domains,
-levels and preferred programming languages to write more reproducible research code.
+-   **What**: **Intro to git and collaborative git, on github**
+    **When**: 3 days in the second week of September (9+10+11 September 11:00-13:00 + 14:00-15:30 (CEST))
+-   **What**: **Reproducible research**, **tools for documentation and testing**, **modular code development**
+    **When**: spread over 6 following weeks Wednesdays starting on 17th of September until the 22nd of October.
 
-The workshop is held online (streamed on Twitch) with interactive hands-on sessions during the first week.
-Some locations may offer in-person events, and you may also join with your own classroom
-(please contact us if this option sparks your interest).
+The intended audience for this workshop are researchers of all domains, levels and preferred programming languages who write code in their research, and the aim is to improve the reproducibility of our research by deepening the knowledge of the tools that enable better code development and sharing.
+
+The workshop is held **online** (streamed on Twitch) with hands-on sessions.
+Interaction with the participants and live help is guaranteed by a variety of means.
+Some locations may offer in-person events (check the [event page](https://coderefinery.github.io/2025-09-09-workshop/)), and **feel encouraged to join as a team** with your colleagues and form your own classroom (please contact us if this option sparks your interest).
 
 The event is free of charge.
+More info and registration on the [CodeRefinery Workshop site](https://coderefinery.github.io/2025-09-09-workshop/).
 
-More info and registration on the CodeRefinery-workshop site: https://coderefinery.github.io/2025-09-09-workshop/
-- In case of any questions, please contact support@coderefinery.org
+In case of any questions, please contact support@coderefinery.org


### PR DESCRIPTION
- Content: removed "exercises only in the first week", elaborated on the intended audience, some rewording with more specific words (but I might be mistaken)
- Form: Using some markdown (that can be rendered to html) to have some links, plus some **bold** so that important information is quicker to see.

Take this as a weak suggestion, feel free to ignore.
