### PR TITLE
templates/schedule: Only show date on first day of each schedule

### DIFF
--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -35,8 +35,8 @@
       </tr>
       {% for session in day.sessions %}
         <tr>
-          <td class="uk-width-2-5">
-            {{ macros::local_date(date=day.date, time=session.ends) }},
+          <td class="uk-width-2-5", style="text-align: right ;">
+            {% if loop.first %}{{ macros::local_date(date=day.date, time=session.ends) }},{% endif %}
             {{ macros::local_time(date=day.date, time=session.starts) }}
             -
             {{ macros::local_time(date=day.date, time=session.ends) }}


### PR DESCRIPTION
- This places the date on only the first session of each day, instead
  of on every session.
- In theory the date is needed on every row, since depending on your
  timezone different sessions on a "day" may be on different local
  days.
- But those people can probably figure out that it spans a day and
  mentally adjust.  That is what would happen if it wasn't converted
  to their own timezone anyway.
- To me the benefit here is that it's easier to scan vertically and
  divide up the schedule into distinct days, and understand each day
  separately.
