### PR TITLE
Fix footer typo

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,7 +4,7 @@
     <h4>Funding</h4>
     <p>
       CodeRefinery is a project within the
-      <a href="https://neic.no" target="_blank">Nordic e-Infrastructure Collaboration</a> (NeIC)." target="_blank">NordForsk</a>.
+      <a href="https://neic.no" target="_blank">Nordic e-Infrastructure Collaboration</a> (NeIC).
     </p>
   </div>
 


### PR DESCRIPTION
Fixing a broken HTML tag left behind by 4c4702dfc222af02a8f5caadcc641b6ad97debc5.